### PR TITLE
FIX: Remove Assumption of Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,19 @@ This gem accepts a JSON object of a particular format and returns a valid GraphQ
 should yield
 
 ```graphql
-  {
-    query($x: 1, $y: 2) {
-      libraries(id: 123) {
+  query($x: 1, $y: 2) {
+    libraries(id: 123) {
+      name
+      address
+      devices(price: 40) {
+        price
         name
-        address
-        devices(price: 40) {
-          price
-          name
-          author
-        }
-        employees(department: history){
-          name
-          age
-          department
-        }
+        author
+      }
+      employees(department: history){
+        name
+        age
+        department
       }
     }
   }

--- a/lib/json_to_graphql.rb
+++ b/lib/json_to_graphql.rb
@@ -4,6 +4,6 @@ require 'json'
 
 module JsonToGraphql
   def self.parse(json_string)
-    JsonToGraphql::Parser.new(JSON.parse(json_string)).print
+    JsonToGraphql::Parser.new(JSON.parse(json_string)).print.chomp("\n}").reverse.chomp("  \n{").reverse
   end
 end

--- a/test/json_to_graphql_test.rb
+++ b/test/json_to_graphql_test.rb
@@ -32,17 +32,15 @@ class JsonToGraphqlTest < Minitest::Test
 
   def output_query
     <<~QUERY.chomp
-      {
-        query($x: 1,$y: 2) {
-          lines(id: 123) {
+      query($x: 1,$y: 2) {
+        lines(id: 123) {
+          name
+          age
+          devices(price: 40) {
+            price
             name
-            age
-            devices(price: 40) {
-              price
-              name
-            }
-            people{
-            }
+          }
+          people{
           }
         }
       }


### PR DESCRIPTION
Graphql allows for shortcut in queries by not requiring the `query` keyword to be prefixed in the payload. For example:

```graphql
{ 
  hero {
    id
  }
}
```

is the same as 

```graphql
query{ 
  hero {
    id
  }
}
```

However, this gem will output 

```graphql
{
  query{ 
    hero {
      id
    }
  }
}
```
Which is incorrect syntax and will yield the following error in GraphQL:

```json
{
    "errors": [
        {
            "message": "Field 'query' doesn't exist on type 'Query'",
            "locations": [
                {
                    "line": 2,
                    "column": 3
                }
            ],
            "fields": [
                "query",
                "mutation"
            ]
        }
    ]
}
```

By doing so, this gem will not allow ``mutation`` to be passed correctly. This fix simply removes the prefixed and suffixed curly braces `{`.

This, however, assumes that you _must_ include either `query` or `mutation` as your top level JSON node.

