### PR TITLE
BUGFIX: fix print with braces

### DIFF
--- a/lib/json_to_graphql/parser.rb
+++ b/lib/json_to_graphql/parser.rb
@@ -22,9 +22,19 @@ module JsonToGraphql
     end
 
     def print
-      root.children.each_with_object("{\n") do |child, query|
-        query.concat("#{child.print("", 1)}")
-      end.concat("}")
+      if input_hash.key?('query')
+        start_string = ""
+        start_space = 0
+      else
+        start_string = "{\n"
+        start_space = 1
+      end
+
+      query = root.children.each_with_object(start_string) do |child, query|
+        query.concat("#{child.print("", start_space)}")
+      end
+      query.concat("}") unless input_hash.key?('query')
+      return query
     end
 
     class Node
@@ -56,7 +66,7 @@ module JsonToGraphql
         elsif !variables.empty?
           '(' + variables.map{|k,v| "$#{k}: #{v}"}.join(',') + ') '
         else
-          "" 
+          ""
         end
       end
     end

--- a/test/json_to_graphql_test.rb
+++ b/test/json_to_graphql_test.rb
@@ -11,6 +11,12 @@ class JsonToGraphqlTest < Minitest::Test
     assert_equal graphql_query.to_s, output_query.to_s
   end
 
+  def test_parser_converts_hash_to_graphql_when_query_key_not_present
+    parser = ::JsonToGraphql::Parser.new(input_hash_without_query_key)
+    graphql_query = parser.print
+    assert_equal graphql_query.to_s, output_query_without_query_key.to_s
+  end
+
   def input_hash
     {
       "query" => {
@@ -30,22 +36,51 @@ class JsonToGraphqlTest < Minitest::Test
     }
   end
 
-  def output_query
+  def input_hash_without_query_key
+    {
+      "lines" => {
+        "_args" => {
+          "id" => 123
+        }, "_attrs" => [:name,:age], "devices" => {
+          "_args" => {
+            "price" => 40
+          }, "_attrs" => [:price,:name]
+        }, "people" => {}
+      }
+    }
+  end
+
+  def output_query_without_query_key
     <<~QUERY.chomp
-      {
-        query($x: 1,$y: 2) {
-          lines(id: 123) {
-            name
-            age
-            devices(price: 40) {
-              price
-              name
-            }
-            people{
-            }
-          }
+    {
+      lines(id: 123) {
+        name
+        age
+        devices(price: 40) {
+          price
+          name
+        }
+        people{
         }
       }
+    }
+    QUERY
+  end
+
+  def output_query
+    <<~QUERY
+    query($x: 1,$y: 2) {
+      lines(id: 123) {
+        name
+        age
+        devices(price: 40) {
+          price
+          name
+        }
+        people{
+        }
+      }
+    }
     QUERY
   end
 end


### PR DESCRIPTION
When a user includes the "query" key in the input JSON, we should not
include surrounding braces. Otherwise we should.